### PR TITLE
Add Change record and handle diff reflection access

### DIFF
--- a/todoapp/src/main/java/org/savea/todoapp/config/Change.java
+++ b/todoapp/src/main/java/org/savea/todoapp/config/Change.java
@@ -1,0 +1,3 @@
+package org.savea.todoapp.config;
+
+public record Change<T>(T oldValue, T newValue) {}

--- a/todoapp/src/main/java/org/savea/todoapp/config/DiffUtil.java
+++ b/todoapp/src/main/java/org/savea/todoapp/config/DiffUtil.java
@@ -2,11 +2,12 @@ package org.savea.todoapp.config;
 
 import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 
 public class DiffUtil{
 
-    public static Map<String, Change<?>> diff(Object oldObj, Object newObj) {
+    public static Map<String, Change<?>> diff(Object oldObj, Object newObj) throws IllegalAccessException {
         Map<String, Change<?>> changes = new LinkedHashMap<>();
         for (Field f : oldObj.getClass().getDeclaredFields()) {
             f.setAccessible(true);

--- a/todoapp/src/main/java/org/savea/todoapp/services/ActivityService.java
+++ b/todoapp/src/main/java/org/savea/todoapp/services/ActivityService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.AuditReaderFactory;
 import org.savea.todoapp.config.DiffUtil;
+import org.savea.todoapp.config.Change;
 import org.savea.todoapp.controllers.ActivityDto;
 import org.savea.todoapp.models.Task;
 import org.savea.todoapp.models.UserRevision;
@@ -32,8 +33,13 @@ public class ActivityService {
                     Task snapshot = reader.find(Task.class, taskId, rev);
                     UserRevision meta = reader.findRevision(UserRevision.class, rev);
 
-                    Map<String, Change<?>> diff = i == 0 ? Map.of()
-                            : DiffUtil.diff(reader.find(Task.class, taskId, revNums.get(i - 1)), snapshot);
+                    Map<String, Change<?>> diff;
+                    try {
+                        diff = i == 0 ? Map.of()
+                                : DiffUtil.diff(reader.find(Task.class, taskId, revNums.get(i - 1)), snapshot);
+                    } catch (IllegalAccessException e) {
+                        throw new RuntimeException(e);
+                    }
 
                     return new ActivityDto(rev.longValue(),
                             meta.getRevisionDate(),


### PR DESCRIPTION
## Summary
- add missing `java.util.Map` import in `DiffUtil`
- introduce new `Change` record for holding field changes
- throw and handle `IllegalAccessException` when diffing objects

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68562ecec1288320aceff982af851068