### PR TITLE
Add ClientIpFilter

### DIFF
--- a/SpringBootTesting/src/main/java/org/savea/filters/ClientIpFilter.java
+++ b/SpringBootTesting/src/main/java/org/savea/filters/ClientIpFilter.java
@@ -1,0 +1,29 @@
+package org.savea.filters;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Filter that stores the remote address of each request under the
+ * {@code CLIENT_IP} attribute before continuing the filter chain.
+ */
+@Component
+public class ClientIpFilter extends OncePerRequestFilter {
+
+    public static final String CLIENT_IP = "CLIENT_IP";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+        request.setAttribute(CLIENT_IP, request.getRemoteAddr());
+        filterChain.doFilter(request, response);
+    }
+}

--- a/SpringBootTesting/src/test/java/org/savea/unit/ClientIpFilterTest.java
+++ b/SpringBootTesting/src/test/java/org/savea/unit/ClientIpFilterTest.java
@@ -1,0 +1,33 @@
+package org.savea.unit;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.savea.filters.ClientIpFilter;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+class ClientIpFilterTest {
+
+    @Test
+    void addsRemoteAddressToRequest() throws ServletException, IOException {
+        ClientIpFilter filter = new ClientIpFilter();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        request.setRemoteAddr("127.0.0.1");
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(request.getAttribute(ClientIpFilter.CLIENT_IP))
+                .isEqualTo("127.0.0.1");
+        verify(chain).doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ClientIpFilter` to expose the request's remote address as a request attribute
- test that the filter stores the remote address before proceeding

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68562eeb40c8832082bae02e966b695b