### PR TITLE
Fix TaskController integration test by handling missing client IP

### DIFF
--- a/todoapp/src/main/java/org/savea/todoapp/config/UserRevisionListener.java
+++ b/todoapp/src/main/java/org/savea/todoapp/config/UserRevisionListener.java
@@ -17,7 +17,8 @@ public class UserRevisionListener implements RevisionListener {
         UserRevision rev = (UserRevision) entity;
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         rev.setUsername(auth != null ? auth.getName() : "anonymous");
-        rev.setIp(RequestContextHolder.currentRequestAttributes()
-                .getAttribute("CLIENT_IP", SCOPE_REQUEST).toString());
+        Object clientIp = RequestContextHolder.currentRequestAttributes()
+                .getAttribute("CLIENT_IP", SCOPE_REQUEST);
+        rev.setIp(clientIp != null ? clientIp.toString() : "unknown");
     }
 }


### PR DESCRIPTION
## Summary
- avoid NPE in `UserRevisionListener` when `CLIENT_IP` request attribute is absent

## Testing
- `mvn -q -pl todoapp test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685637c713748320bed7815b6e4e3c66