### PR TITLE
Fix comment/task equals recursion

### DIFF
--- a/todoapp/src/main/java/org/savea/todoapp/models/Comment.java
+++ b/todoapp/src/main/java/org/savea/todoapp/models/Comment.java
@@ -3,11 +3,13 @@ package org.savea.todoapp.models;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.hibernate.envers.Audited;
 
 @Entity
 @Audited
 @Data
+@EqualsAndHashCode(exclude = "task")
 public class Comment {
 
     @Id

--- a/todoapp/src/main/java/org/savea/todoapp/models/Task.java
+++ b/todoapp/src/main/java/org/savea/todoapp/models/Task.java
@@ -3,6 +3,7 @@ package org.savea.todoapp.models;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.hibernate.envers.Audited;
 
 import java.util.ArrayList;
@@ -11,6 +12,7 @@ import java.util.List;
 @Entity
 @Audited
 @Data
+@EqualsAndHashCode(exclude = "comments")
 public class Task {
 
     @Id @GeneratedValue


### PR DESCRIPTION
## Summary
- prevent Lombok from including JPA relationships in `equals`/`hashCode`
- add appropriate exclusions in `Task` and `Comment`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564f6df8c08320b7c910a05d41f6c8