### PR TITLE
Make ActivityService generic

### DIFF
--- a/todoapp/README.md
+++ b/todoapp/README.md
@@ -3,7 +3,9 @@
 ## Overview
 This module contains a minimal TODO application built with Spring Boot. It exposes
 REST endpoints for managing tasks and their comments while capturing revision
-history via Hibernate Envers.
+history via Hibernate Envers. The `ActivityService` now uses generics so any
+audited entity can have its activity feed retrieved via
+`activityService.getActivity(YourEntity.class, id)`.
 
 ## Required Dependencies
 The module relies on the following dependencies as declared in `pom.xml`:

--- a/todoapp/src/main/java/org/savea/todoapp/controllers/TaskController.java
+++ b/todoapp/src/main/java/org/savea/todoapp/controllers/TaskController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.savea.todoapp.models.Comment;
 import org.savea.todoapp.models.Task;
 import org.savea.todoapp.services.ActivityService;
+import org.savea.todoapp.controllers.ActivityDto;
 import org.savea.todoapp.services.TaskService;
 import org.savea.todoapp.services.repo.TaskRepository;
 import org.springframework.data.history.Revisions;
@@ -24,7 +25,7 @@ public class TaskController {
 
     @GetMapping("/{id}/activity")
     public List<ActivityDto> feed(@PathVariable Long id) {
-        return activityService.getTaskActivity(id);
+        return activityService.getActivity(Task.class, id);
     }
 
     @PostMapping

--- a/todoapp/src/main/java/org/savea/todoapp/services/ActivityService.java
+++ b/todoapp/src/main/java/org/savea/todoapp/services/ActivityService.java
@@ -7,7 +7,6 @@ import org.hibernate.envers.AuditReaderFactory;
 import org.savea.todoapp.config.DiffUtil;
 import org.savea.todoapp.config.Change;
 import org.savea.todoapp.controllers.ActivityDto;
-import org.savea.todoapp.models.Task;
 import org.savea.todoapp.models.UserRevision;
 import org.springframework.stereotype.Service;
 
@@ -22,22 +21,22 @@ public class ActivityService {
 
     private final EntityManager em;
 
-    public List<ActivityDto> getTaskActivity(Long taskId) {
+    public <T, ID> List<ActivityDto> getActivity(Class<T> entityClass, ID entityId) {
 
         AuditReader reader = AuditReaderFactory.get(em);          // raw Envers
-        List<Number> revNums = reader.getRevisions(Task.class, taskId); // all rev IDs
+        List<Number> revNums = reader.getRevisions(entityClass, entityId); // all rev IDs
 
         return IntStream.range(0, revNums.size())
                 .mapToObj(i -> {
                     Number rev = revNums.get(i);
-                    Task snapshot = reader.find(Task.class, taskId, rev);
+                    T snapshot = reader.find(entityClass, entityId, rev);
                     UserRevision meta = reader.findRevision(UserRevision.class, rev);
 
                     Map<String, Change<?>> diff;
                     try {
                         // If it's the first revision, there's no previous revision to compare against
                         diff = i == 0 ? Map.of()
-                                : DiffUtil.diff(reader.find(Task.class, taskId, revNums.get(i - 1)), snapshot);
+                                : DiffUtil.diff(reader.find(entityClass, entityId, revNums.get(i - 1)), snapshot);
                     } catch (IllegalAccessException e) {
                         throw new RuntimeException(e);
                     }
@@ -51,3 +50,4 @@ public class ActivityService {
                 .toList();
     }
 }
+


### PR DESCRIPTION
## Summary
- generalize activity retrieval so ActivityService can operate on any entity type
- adjust TaskController to use the new generic method
- document generics usage in the todoapp README

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856badcba888320a6ca0eac7807aef0